### PR TITLE
Netlify 기본 도메인 추가 제거

### DIFF
--- a/src/components/SigninForm.tsx
+++ b/src/components/SigninForm.tsx
@@ -48,7 +48,7 @@ export default function SigninForm() {
       
       try {
         // 서버로부터의 응답
-        const response = await fetch(`${BACK_URL}/auth/signin`, {
+        const response = await fetch(`${BACK_URL}/auth/signin`.replace("kmu-likelion-blog.netlify.app/", ""), {
           method: "POST",
           headers: {
             "Content-Type": "application/json"

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -62,7 +62,7 @@ export default function SignupForm() {
         
         // 이메일과 패스워드 변수에 데이터 잘 들어가는 건 확인
         try {
-            const response = await fetch(`${BACK_URL}/auth/signup`, {
+            const response = await fetch(`${BACK_URL}/auth/signup`.replace("kmu-likelion-blog.netlify.app/", ""), {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json"

--- a/src/components/article/PostDetail.tsx
+++ b/src/components/article/PostDetail.tsx
@@ -19,7 +19,7 @@ export default function PostDetail() {
     // id기반으로 서버로부터 데이터 얻어냅니다
     async function getPost(id: string) {
         if(id) {
-            const response = await fetch(`//${BACK_URL}/post/${id}`, {
+            const response = await fetch(`${BACK_URL}/post/${id}`.replace("kmu-likelion-blog.netlify.app/", ""), {
                 method: "GET",
                 headers: {
                     "Authorization": authToken

--- a/src/components/article/PostForm.tsx
+++ b/src/components/article/PostForm.tsx
@@ -59,7 +59,7 @@ export default function PostForm() {
         try {   
             if(post && post?.id) {
                 // 기존 게시물을 수정하는 경우의 내용 : PUT
-                const response = await fetch(`//${BACK_URL}/post`, {
+                const response = await fetch(`${BACK_URL}/post`.replace("kmu-likelion-blog.netlify.app/", ""), {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",

--- a/src/components/article/PostList.tsx
+++ b/src/components/article/PostList.tsx
@@ -18,7 +18,7 @@ export default function PostList({
         const postData = async () => {
             try {
                 // 응답값 : 포스트들 : 배열
-                const response = await fetch(`${BACK_URL}/post`, {
+                const response = await fetch(`${BACK_URL}/post`.replace("kmu-likelion-blog.netlify.app/", ""), {
                     method: "GET",
                     headers: {
                         "Authorization": authToken


### PR DESCRIPTION
Netlify로 배포시 발생하는 기본 추가 도메인을 제거하고 서버 api와 통신하기 위해 fetch함수 호출시, 뒤에 추가로 메서드를 붙였습니다.